### PR TITLE
Fixed "Website Opens at the Bottom of the Page Upon Load"

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      window.onload = function() {
+          window.scrollTo(0, 0);  // Always scroll to top on reload
+      };
+  </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes: #83 

### Steps to check:

1. Open the website.
2. Observe that the page scrolls to the bottom instead of remaining at the top.
It will not; it will stay on top


https://github.com/user-attachments/assets/9ba39e9e-cede-4307-a02e-c93b4fa2a105





