### PR TITLE
Fix start and stop button margins

### DIFF
--- a/src/components/controls.jsx
+++ b/src/components/controls.jsx
@@ -207,12 +207,12 @@ const Controls = ({ isRunning, handleStartStop, handleLap, handleReset }) => {
           {isRunning ? (
             <>
               <Pause className="z-10 mr-2 h-4 w-4" />
-              <span className="z-10">Stop</span>
+              <span className="mr-2 z-10">Stop</span>
             </>
           ) : (
             <>
               <Play className="z-10 mr-2 h-4 w-4" />
-              <span className="z-10">Start</span>
+              <span className="mr-2 z-10">Start</span>
             </>
           )}
         </Button>


### PR DESCRIPTION
Hello!

I’ve adjusted the margin on the `Start` and `Stop` buttons, as they were slightly misaligned compared to the other buttons. This is a small fix, but I believe it brings more consistency to the overall appearance.

I’ve attached before and after images for your reference.

Before
<img width="603" alt="counter-app_1_before" src="https://github.com/user-attachments/assets/088e2f0f-54b4-4609-99d3-57597f2baf74">

After
<img width="593" alt="counter-app_2_after" src="https://github.com/user-attachments/assets/41bc61c4-b35e-4161-8371-fd2324b6472e">


I’d be happy to get your thoughts on this!
Best regards!