### PR TITLE
[Bug] : #176 Dark mode is not functional in about us page

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,15 +1,31 @@
-import { Button } from "./ui/button"
+import { Button } from './ui/button'
 import { Clock, BarChart, Users, Mail, Globe, Shield, Zap, Timer, BarChart2, Layers } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card"
-import Navbar from "./navbar"
+import  Navbar from "./navbar"
 import {delay, motion} from 'framer-motion'
-import { useState } from "react"
+import React, { useState, useEffect, useCallback, useRef } from "react"
 
 
 const About= ()=>{
+    const [theme, setTheme] = useState("light");
+    useEffect(() => {
+        const storedTheme = localStorage.getItem("theme");
+        if (storedTheme) {
+          setTheme(storedTheme);
+        }
+      }, []);
+    
+      useEffect(() => {
+        document.body.className = theme;
+        localStorage.setItem("theme", theme);
+      }, [theme]);
+    
+      const toggleTheme = () => {
+        setTheme((prevTheme) => (prevTheme === "dark" ? "light" : "dark"));
+      };
 
     const [isOpen,setIsOpen]= useState(false)
-
+    
     const transition = {
         duration: 1.5
       };
@@ -30,9 +46,12 @@ const About= ()=>{
 
       const summary=` Counter Clock is not just a timekeeping application; it's a revolution in how we perceive and manage our most valuable resource - time. Born from the need for precision and efficiency in our fast-paced world, Counter Clock has quickly become the cornerstone of productivity for individuals and teams across the globe.`
       const long = `${summary}\nSince our inception in 2023, we've been on a mission to transform time management from a mundane task into an empowering experience. Our state-of-the-art technology, coupled with an intuitive interface, ensures that every second counts towards your success.`;
-       return(
+       
+      
+      
+      return(
         <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-            <Navbar/>
+            <Navbar theme={theme} toggleTheme={toggleTheme} />
             <header className="bg-gradient-to-r from-blue-500 to-indigo-600 dark:from-blue-700 dark:to-indigo-800 text-white py-20">
                 <div className="container mx-auto px-4">
                     <div className="flex flex-col lg:flex-row items-center justify-between">


### PR DESCRIPTION
# 🚀Pull Request: 

**Issue : [Dark mode is not functional in about us page] #176**

## Fix Dark Mode Functionality on "About Us" Page
This PR resolves the issue where the "About Us" page does not properly switch to dark mode when toggled. Currently, while other pages on the site reflect the dark mode setting correctly, the "About Us" page remains in light mode.

**Bug Description: Dark mode is not functioning properly on the "About Us" page.**

## Changes Made
<ul>
<li>Modified the JavaScript function responsible for toggling the theme to include a specific selector for the "About Us" page.</li>
<li>Verified that the changes do not affect the dark mode functionality on other pages.</li>
</ul>

## Steps to Test
<ul>
<li>Navigate to the "About Us" page.</li>
<li>Toggle dark mode using the switch or button.</li>
<li>Verify that the "About Us" page now correctly reflects the dark mode styling.</li>
</ul>

## Former Behaviour

Before this fix, the "About Us" page remained in light mode even after dark mode was activated.

## Behaviour after fix

After the changes, toggling dark mode should result in the "About Us" page transitioning to dark mode, consistent with the behaviour of other pages.

## Screen recording to show the working of theme toggle :

https://github.com/user-attachments/assets/b53d3468-6913-47c3-b106-2e945f01e820

 

