### PR TITLE
[Bug]: #226 Home Page Starts from the Bottom on Direct Load

### DIFF
--- a/src/pages/AutoCounterPage.jsx
+++ b/src/pages/AutoCounterPage.jsx
@@ -68,10 +68,6 @@ const AutoCounterPage = () => {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, [laps]);
-  useEffect(() => {
-    lapsEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [laps]);
-
    const formatTime = useCallback((time) => {
     const minutes = Math.floor(time / 6000);
     const seconds = Math.floor((time % 6000) / 100);

--- a/src/pages/AutoCounterPage.jsx
+++ b/src/pages/AutoCounterPage.jsx
@@ -65,7 +65,9 @@ const AutoCounterPage = () => {
       if (interval) clearInterval(interval);
     };
   }, [isRunning]);
-
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [laps]);
   useEffect(() => {
     lapsEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [laps]);


### PR DESCRIPTION
### 🐞Bug report

## Title: Fix Page Scroll Issue on Direct Load

## Description: 
This PR addresses a bug where the homepage starts from the bottom of the page when opened directly, causing a poor user experience. While investigating another issue related to the timer lap button, I noticed this behaviour and decided to fix it.

Ensured that the page now starts from the top on load.

Added a minor scroll behaviour fix to improve the page navigation.


## Related Issue: #176 

## Changes Made:

<li>Fixed page load behaviour to start from the top.</li>
<li>Minor improvements to the scroll handling.</li>


## Testing: 

Tested across different browsers to confirm the issue is resolved and the page now opens at the top by default.

## Page loading initially: 

https://github.com/user-attachments/assets/621793fe-bd2a-4b04-8e7c-d6b10f9b3a5b

## Page loading after fix:

https://github.com/user-attachments/assets/807ee0f7-95cf-4169-b613-349e3141ed8f



